### PR TITLE
fix: export all where parameters

### DIFF
--- a/lib/parameter/index.ts
+++ b/lib/parameter/index.ts
@@ -1,7 +1,7 @@
 export { default as Parameter } from './parameter';
 
-import { Where } from './where';
-export const where = { Where };
+import * as Where from './where';
+export const where = { ...Where }
 
 export { default as headers } from './headers';
 export { default as params } from './params';

--- a/lib/parameter/parameter.ts
+++ b/lib/parameter/parameter.ts
@@ -7,7 +7,7 @@ export default class Parameter {
   combineLevel: number;
 
   constructor(
-    public readonly where = new Where(null, true, true, true),
+    public readonly where: Where | unknown = new Where(null, true, true, true),
     options?: {
       name?: string,
       as?: string,


### PR DESCRIPTION
`parameter.where.params`, `parameter.where.query` 등을 사용할 수 없었던 문제 해결
